### PR TITLE
Update “Donate” page link

### DIFF
--- a/_posts/2019-06-06-FundRaising.md
+++ b/_posts/2019-06-06-FundRaising.md
@@ -22,6 +22,6 @@ author: Mark Howe
 * Centralized Calendar for all government/public meetings
 
 
-[Donate](https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20Pittsburgh) to help your local Code for Pittsburgh brigade! 
+[Donate](https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20Pittsburgh&utm_source=CodeforPittsburgh%20site) to help your local Code for Pittsburgh brigade! 
 
 [Our meetup page](https://www.meetup.com/codeforpgh)


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ