### PR TITLE
Fix for map search truncation, basic styling for results dropdown

### DIFF
--- a/FoodAccessMap/script.js
+++ b/FoodAccessMap/script.js
@@ -277,6 +277,7 @@ $.get(
 var search = new L.esri.BootstrapGeocoder.search({
   inputTag: 'searchInput',
   placeholder: 'ex. Bloomfield',
+  useMapBounds: false
 }).addTo(map);
 // let gjp = new L.geoJson(points);
 

--- a/FoodAccessMap/script.js
+++ b/FoodAccessMap/script.js
@@ -274,10 +274,15 @@ $.get(
   }
 );
 // var searchControl = new L.esri.Controls.Geosearch({zoomToResult:false}).addTo(map);
+
+var nwBoundsCorner = L.latLng(40.507486, -80.063847);
+var seBoundsCorner = L.latLng(40.385017, -79.837699);
+var mapBounds = L.latLngBounds(nwBoundsCorner, seBoundsCorner);
+
 var search = new L.esri.BootstrapGeocoder.search({
   inputTag: 'searchInput',
   placeholder: 'ex. Bloomfield',
-  useMapBounds: false
+  searchBounds: mapBounds
 }).addTo(map);
 // let gjp = new L.geoJson(points);
 

--- a/FoodAccessMap/style.css
+++ b/FoodAccessMap/style.css
@@ -26,6 +26,10 @@ html {
   width: 180px;
 }
 
+.geocoder-control-selected {
+  background-color: #888888;
+}
+
 #results {
   clear: left;
 }

--- a/FoodAccessMap/style.css
+++ b/FoodAccessMap/style.css
@@ -26,8 +26,14 @@ html {
   width: 180px;
 }
 
+.geocoder-control-suggestion {
+  list-style-type: none;
+}
+.geocoder-control-suggestion:hover {
+  background-color: #DDD;
+}
 .geocoder-control-selected {
-  background-color: #888888;
+  background-color: #AAA;
 }
 
 #results {


### PR DESCRIPTION
Added a searchBounds option to the options passed into the BootstrapGeocoder search.  

**Consider modifying the boundary extents I chose without input! :D**

Added primitive and frankly grotesque styling to the options in the search dropdown.  
Please, have pity on our sins, gods of UX design.
